### PR TITLE
[Step1] 함수로 만드는 Github Issue Page

### DIFF
--- a/data-sources/labels.json
+++ b/data-sources/labels.json
@@ -1,0 +1,32 @@
+[
+    {
+        "name":"bug",
+        "color":"bfdadc",
+        "description":"this is red"
+    },
+    {
+        "name":"documentation",
+        "color":"0075ca",
+        "description":"this is documetation"
+    },
+    {
+        "name":"enhancement",
+        "color":"a2eeef",
+        "description":"this is enhancement"
+    },
+    {
+        "name":"question",
+        "color":"d876e3",
+        "description":"this is question"
+    },
+    {
+        "name":"invalid",
+        "color":"e4e669",
+        "description":"this is not valid"
+    },
+    {
+        "name":"duplicate",
+        "color":"cfd3d7",
+        "description":"this is dulicate"
+    }
+]

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,0 +1,10 @@
+import {asyncPipe} from "./fp-helpers.js";
+
+const fetchLabels = asyncPipe(
+  () => fetch('/data-sources/labels.json'),
+  res => res.json()
+);
+export const fetchIssues = asyncPipe(
+  () => fetch('data-sources/issues.json'),
+  res => res.json()
+);

--- a/src/fp-helpers.js
+++ b/src/fp-helpers.js
@@ -1,0 +1,12 @@
+export const pipe = (...args) => (val) => args.reduce((acc, curr) => curr(acc), val);
+
+export const asyncPipe = (...args) => val => args.reduce(async (y, fn) => fn(await y), val);
+
+export const tab = fn => data => {
+  fn(data);
+  return data;
+};
+
+export const filter = fn => data => data.filter(fn);
+
+export const forEach = fn => data => data.forEach(fn);

--- a/src/main.js
+++ b/src/main.js
@@ -19,8 +19,14 @@ function renderIssueItemElement(issue) {
     document.querySelector('.issue-list ul').appendChild(newIssueItemElement);
 }
 
+function renderStatusNum(allIssueNum, openedNum) {
+    document.getElementsByClassName('open-count')[0].innerText = openedNum + ' Opened';
+    document.getElementsByClassName('close-count')[0].innerText = (allIssueNum - openedNum) + ' Closed';
+}
+
 document.getElementById('app').innerHTML = getIssueTpl();
 fetchIssues().then(issues => {
-    console.log(issues);
     issues.forEach(renderIssueItemElement);
+    renderStatusNum(issues.length, issues.filter(({status}) => status === "open").length);
 });
+

--- a/src/main.js
+++ b/src/main.js
@@ -1,32 +1,92 @@
 import {getIssueItemTpl, getIssueTpl} from "./tpl.js";
 
-function fetchLabels() {
-    return fetch('/data-sources/labels.json').then(res => res.json());
+const pipe = (...args) => (val) => {
+    args.reduce((acc, curr) => curr(acc), val)
 }
-function fetchIssues() {
-    return fetch('/data-sources/issues.json').then(res => res.json());
+class Observable {
+    constructor() {
+        this.value = undefined;
+        this.callbacks = [];
+    }
+    next(nextValue) {
+        this.callbacks.forEach((fn) => fn(nextValue));
+        this.value = nextValue;
+    }
+    subscribe(callbackFn) {
+        this.callbacks.push(callbackFn);
+    }
+    getValue() {
+        return this.value;
+    }
 }
 
-function htmlToElement(html) {
-    const template = document.createElement('template');
+// Fetch 함수
+const fetchLabels = () => fetch('/data-sources/labels.json').then(res => res.json());
+const fetchIssues = () => fetch('/data-sources/issues.json').then(res => res.json());
+
+const filterOpened = (issues) => issues.filter(({status}) => status === "open");
+const filterClosed = (issues) => issues.filter(({status}) => status === "close");
+
+const htmlToElement = (html) => {
     html = html.trim();
+    const template = document.createElement('template');
     template.innerHTML = html;
     return template.content.firstChild;
 }
 
-function renderIssueItemElement(issue) {
-    const newIssueItemElement = htmlToElement(getIssueItemTpl(issue));
-    document.querySelector('.issue-list ul').appendChild(newIssueItemElement);
+// Render 함수
+const renderIssue = pipe(
+  getIssueItemTpl,
+  htmlToElement,
+  (issueElement) => document.querySelector('.issue-list ul').appendChild(issueElement),
+);
+
+const renderIssueTemplate = () => document.getElementById('app').innerHTML = getIssueTpl();
+const renderIssues = (issues) => {
+    document.querySelector('.issue-list ul').innerHTML = '';
+    issues.forEach(renderIssue);
 }
+const renderOpenedNum = (openedNum) => document.getElementsByClassName('open-count')[0].innerText = openedNum + ' Opened';
+const renderClosedNum = (closedNum) => document.getElementsByClassName('close-count')[0].innerText = closedNum + ' Closed';
 
-function renderStatusNum(allIssueNum, openedNum) {
-    document.getElementsByClassName('open-count')[0].innerText = openedNum + ' Opened';
-    document.getElementsByClassName('close-count')[0].innerText = (allIssueNum - openedNum) + ' Closed';
-}
+// data fetch 구독
+const issues$ = new Observable();
+issues$.subscribe(renderIssues);
+issues$.subscribe(
+  pipe(
+    filterOpened,
+    issues => issues.length,
+    renderOpenedNum,
+  )
+);
+issues$.subscribe(
+  pipe(
+    filterClosed,
+    issues => issues.length,
+    renderClosedNum,
+  )
+);
 
-document.getElementById('app').innerHTML = getIssueTpl();
-fetchIssues().then(issues => {
-    issues.forEach(renderIssueItemElement);
-    renderStatusNum(issues.length, issues.filter(({status}) => status === "open").length);
-});
+// button clickevent 구독
+const clickOpened$ = new Observable();
+clickOpened$.subscribe(
+  pipe(
+    () => issues$.getValue(),
+    filterOpened,
+    renderIssues
+  )
+);
 
+const clickClosed$ = new Observable();
+clickClosed$.subscribe(
+  pipe(
+    () => issues$.getValue(),
+    filterClosed,
+    renderIssues
+  )
+);
+
+renderIssueTemplate();
+fetchIssues().then(issues$.next.bind(issues$));
+document.getElementsByClassName('open-count')[0].addEventListener('click', () => clickOpened$.next());
+document.getElementsByClassName('close-count')[0].addEventListener('click', () => clickClosed$.next());

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,26 @@
+import {getIssueItemTpl, getIssueTpl} from "./tpl.js";
+
+function fetchLabels() {
+    return fetch('/data-sources/labels.json').then(res => res.json());
+}
+function fetchIssues() {
+    return fetch('/data-sources/issues.json').then(res => res.json());
+}
+
+function htmlToElement(html) {
+    const template = document.createElement('template');
+    html = html.trim();
+    template.innerHTML = html;
+    return template.content.firstChild;
+}
+
+function renderIssueItemElement(issue) {
+    const newIssueItemElement = htmlToElement(getIssueItemTpl(issue));
+    document.querySelector('.issue-list ul').appendChild(newIssueItemElement);
+}
+
+document.getElementById('app').innerHTML = getIssueTpl();
+fetchIssues().then(issues => {
+    console.log(issues);
+    issues.forEach(renderIssueItemElement);
+});

--- a/src/observable.js
+++ b/src/observable.js
@@ -1,0 +1,16 @@
+export class Observable {
+  constructor() {
+    this.value = undefined;
+    this.callbacks = [];
+  }
+  next(nextValue) {
+    this.callbacks.forEach((fn) => fn(nextValue));
+    this.value = nextValue;
+  }
+  subscribe(callbackFn) {
+    this.callbacks.push(callbackFn);
+  }
+  getValue() {
+    return this.value;
+  }
+}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,22 @@
+import {getIssueItemTpl, getIssueTpl} from "./tpl.js";
+import {pipe, tab} from "./fp-helpers.js";
+
+document.getElementById('app').innerHTML = getIssueTpl();
+export const openedButtonElement = document.getElementsByClassName('open-count')[0];
+export const closedButtonElement = document.getElementsByClassName('close-count')[0];
+const issuesListElement = document.querySelector('.issue-list ul');
+const htmlToElement = pipe(
+  html => html.trim(),
+  (html) => ({ele: document.createElement('template'), html}),
+  tab(({ele, html}) => ele.innerHTML = html),
+  ({ele}) => ele.content.firstChild
+);
+const appendIssueElement = (issueElement) => issuesListElement.appendChild(issueElement);
+export const renderIssuesClear = () => issuesListElement.innerHTML = '';
+export const renderOpenedNum = (openedNum) => openedButtonElement.innerText = openedNum + ' Opened';
+export const renderClosedNum = (closedNum) => closedButtonElement.innerText = closedNum + ' Closed';
+export const renderIssue = pipe(
+  getIssueItemTpl,
+  htmlToElement,
+  appendIssueElement,
+);


### PR DESCRIPTION
### 기능 요구 사항
- 헤더영역에 opens, closed 갯수를 올바르게 표시
- 본문영역에 issue 리스트를 표시
- opens , closed 버튼을 선택하면 각각 해당하는 내용을 노출.

### 구현 설명
Observer pattern을 이용하여 fetch해서 받아온 데이터와 이벤트 발생 시 구독하고 있는 렌더링 함수들을 실행하는 방식으로 구현하였습니다.
구독 시 실행 함수는 함수를 작게 쪼개고 pipe를 사용하여 함수형 프로그래밍으로 구현하였습니다.

### 개선할 사항
- [x] 비동기 처리 pipe로 구현하기
- [ ] 에러 처리 pipe로 구현하기
- [x] 관심사 모듈별로 분리하여 가독성 좋게 개선
- [x] this 바인딩을 좀더 깔끔하게 할 수 있는 방법 고민
- [ ] Opened / Closed 버튼 Active 시 Bold 처리 추가