### PR TITLE
WEEK-1 함수로 만드는 Github Issue Page

### DIFF
--- a/src/fp.js
+++ b/src/fp.js
@@ -1,0 +1,32 @@
+export const curry = f => (a, ..._) => _.length ? f(a, ..._) : (..._) => f(a, ..._);
+
+export const map = curry((f, iter) => {
+  let res = [];
+  for (const a of iter) {
+    res.push(f(a));
+  }
+  return res;
+});
+
+export const filter = curry((f, iter) => {
+  let res = [];
+  for (const a of iter) {
+    if (f(a)) res.push(a);
+  }
+  return res;
+});
+
+export const reduce = curry((f, acc, iter) => {
+  if (!iter) {
+    iter = acc[Symbol.iterator]();
+    acc = iter.next().value;
+  }
+  for (const a of iter) {
+    acc = f(acc, a);
+  }
+  return acc;
+});
+
+export const go = (_, ...fs) => reduce((_, f) => f(_), _, fs);
+
+export const pipe = (f, ...fs) => (...as) => go(f(...as), ...fs);

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,77 @@
+import { getIssueTpl, getIssueItemTpl } from './tpl';
+import { curry, go, filter, map } from './fp';
+
+let $app = null;
+let $issueList = null;
+let $openCount = null;
+let $closeCount = null;
+let issueData = null;
+
+function init() {
+  $app = document.getElementById('app');
+  $app.innerHTML = getIssueTpl();
+  $issueList = document.querySelector('.issue-list ul');
+  $openCount = document.querySelector('.statusTab .open-count');
+  $closeCount = document.querySelector('.statusTab .close-count');
+}
+
+async function fetchData(...nameList) {
+  const arr = await Promise.all(
+    nameList
+      .map(async (name) => {
+        return await (await fetch(`/data-sources/${name}.json`)).json();
+      })
+  );
+  return arr;
+}
+
+const setHTML = curry((dom, html) => {
+  dom.innerHTML = html;
+  return dom;
+});
+
+function renderIssue(issues) {
+  go(
+    issues,
+    map(issue => getIssueItemTpl(issue)),
+    issue => issue.join(''),
+    setHTML($issueList)
+  )
+}
+
+function filterIssue(status) {
+  return go(
+    issueData,
+    filter(issue => issue.status === status)
+  );
+}
+
+async function main() {
+  init();
+
+  // Data Fetch
+  [issueData] = await fetchData('issues');
+
+  const openIssueCount = filterIssue('open').length;
+  const closeIssueCount = filterIssue('close').length;
+
+  // Set HTML
+  $openCount.innerHTML = `${openIssueCount} Opens`;
+  $closeCount.innerHTML = `${closeIssueCount} Closed`;
+
+  renderIssue(issueData);
+
+  // ClickEvent
+  $openCount.addEventListener('click', () => {
+    renderIssue(filterIssue('open'));
+    $openCount.classList.add('font-bold');
+    $closeCount.classList.remove('font-bold');
+  });
+  $closeCount.addEventListener('click', () => {
+    renderIssue(filterIssue('close'));
+    $closeCount.classList.add('font-bold');
+    $openCount.classList.remove('font-bold');
+  });
+}
+
+main();

--- a/src/style.css
+++ b/src/style.css
@@ -53,6 +53,7 @@ li {
   }
   
   .issue-list li {
+    display: flex;
     @apply border-b p-4
   }
 

--- a/src/tpl.js
+++ b/src/tpl.js
@@ -29,7 +29,7 @@ export function getIssueTpl() {
         </div>
 
         <div class="statusTab flex">
-          <div class="whitespace-nowrap open-count font-bold cursor-pointer">0 Opens</div>
+          <div class="whitespace-nowrap open-count cursor-pointer">0 Opens</div>
           <div class="whitespace-nowrap close-count ml-3 cursor-pointer">0 Closed</div>
         </div>
 


### PR DESCRIPTION
> FP에 대한 이해가 부족해, 이에 대한 공부를 진행하느라 시간이 많이 소요되어 제출이 지연되었습니다. 😢

**기능 요구 사항**
- [ ] 초기 로딩시에 위 화면과 같은 화면을 보여준다.
- [ ] 헤더영역에 opens, closed 갯수를 올바르게 표시
- [ ] 본문영역에 issue 리스트를 표시
- [ ] opens , closed 버튼을 선택하면 각각 해당하는 내용을 노출.

**프로그래밍 요구사항**
- [ ] 데이터 요청 초기 데이터는 fetch 요청을 통해서 가져온다.
  - fetch 요청을 사용하고, 확장성을 위해 복수의 데이터를 요청할 수 있음을 감안하여 Promise.all로 처리하였습니다.
- [ ] 배열의 고참 함수 적극 사용.
  - go 함수를 활용하였습니다.
- [ ] 여러개의 작은 함수를 만들어야 함.
  - 외부효과가 없는 각 기능 단위의 함수를 생성하였습니다.
- [ ] 중복 코드 최대한 없게.
  - 가급적 중복 코드를 없애고자 했으나, 아직 개선의 여지가 있습니다.
- [ ] 콜백함수도 가급적 분리
  - 아직 개선의 여지가 있습니다.
- [ ] ES Modules 활용
  - curry, go 등 Funtional Programming을 위한 함수들은 별도로 분리하여 import 하였으나, 그 외 부분에 대해서는 모듈화가 좀더 필요해보입니다.
