### PR TITLE
WEEK-2 객체로 만드는 Github Issue Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,14 @@
 
 <body>
   <nav class="flex justify-end py-8 w-full m-auto text-1xl bg-neutral-800" style="padding-right: 12.5rem;">
-    <button class="mr-4 base-outer p-2 px-5">Issue</button>
-    <button class="base-outer p-2 px-5">Label</button>
+    <button id="issuePageButton" class="mr-4 base-outer p-2 px-5">Issue</button>
+    <button id="labelPageButton" class="base-outer p-2 px-5">Label</button>
   </nav>
 
   <div id="app" class="py-8">
   </div>
 
   <script type="module" src="./src/main.js"></script>
-  <script src="./src/lib/fx.js"></script>
 </body>
 
 </html>

--- a/src/api/issue.js
+++ b/src/api/issue.js
@@ -1,0 +1,8 @@
+const IssueApi = {
+  async fetchIssues() {
+    const res = await fetch('../../data-sources/issues.json');
+    return res.json();
+  },
+};
+
+export default IssueApi;

--- a/src/api/label.js
+++ b/src/api/label.js
@@ -1,0 +1,8 @@
+const LabelApi = {
+  async fetchLabels() {
+    const res = await fetch('../../data-sources/labels.json');
+    return res.json();
+  },
+};
+
+export default LabelApi;

--- a/src/components/component.js
+++ b/src/components/component.js
@@ -1,13 +1,27 @@
 export class BaseComponent {
+  _element = null;
+
   constructor(htmlString) {
+    this.setElement(htmlString);
+
+    this.mounted();
+  }
+
+  mounted = () => {};
+
+  removeFrom = (parent) => {
+    parent.removeChild(this._element);
+  };
+
+  setElement = (htmlString) => {
     const template = document.createElement('template');
     template.innerHTML = htmlString;
 
-    // _를 통해 protected를 명시하며, 읽기 전용 속성으로 만든다.
     this._element = template.content.firstElementChild;
-  }
+  };
 
-  attatchTo(parent, position = 'afterbegin') {
+  attatchTo = (parent, position = 'afterbegin') => {
     parent.insertAdjacentElement(position, this._element);
-  }
+    this.mounted(); // render 후에 mounted가 실행 된다.
+  };
 }

--- a/src/components/issue/issueItem.js
+++ b/src/components/issue/issueItem.js
@@ -1,0 +1,11 @@
+// Components
+import { BaseComponent } from '../component';
+
+// Templates
+import { getIssueItemTpl } from '../../tpl';
+
+export class IssueItem extends BaseComponent {
+  constructor(item) {
+    super(getIssueItemTpl(item));
+  }
+}

--- a/src/components/label/labelItem.js
+++ b/src/components/label/labelItem.js
@@ -1,0 +1,11 @@
+// Components
+import { BaseComponent } from '../component';
+
+// Templates
+import { getLabelItemTpl } from '../../tpl';
+
+export class LabelItem extends BaseComponent {
+  constructor({ name, color, description }) {
+    super(getLabelItemTpl({ name, color, description }));
+  }
+}

--- a/src/components/page/item/issue.js
+++ b/src/components/page/item/issue.js
@@ -1,8 +1,0 @@
-import { BaseComponent } from '../../component.js';
-import { getIssueItemTpl } from '../../../tpl';
-
-export class IssueComponent extends BaseComponent {
-  constructor(item) {
-    super(getIssueItemTpl(item));
-  }
-}

--- a/src/components/page/mainPage.js
+++ b/src/components/page/mainPage.js
@@ -1,8 +1,0 @@
-import { BaseComponent } from '../component.js';
-import { getIssueTpl } from '../../tpl';
-
-export class MainPage extends BaseComponent {
-  constructor(openCount, closedCount) {
-    super(getIssueTpl(openCount, closedCount));
-  }
-}

--- a/src/constants/selector.js
+++ b/src/constants/selector.js
@@ -1,0 +1,21 @@
+export const ROOT = '#app';
+
+/* For Issue Page */
+export const ISSUE_PAGE_BUTTON = '#issuePageButton';
+export const LABEL_PAGE_BUTTON = '#labelPageButton';
+export const ISSUE_LIST = '.issue-list ul';
+export const OPEN_TAB = '#openTab';
+export const CLOSE_TAB = '#closeTab';
+
+/* For Label Page */
+export const LABEL_COUNT = '#labelCount';
+export const NEW_LABEL_BUTTON = '#newLabelButton';
+export const LABEL_INPUT_FORM = '#labelInputForm';
+export const LABEL_NAME_INPUT = '#label-name-input';
+export const LABEL_DESCRIPTION_INPUT = '#label-description-input';
+export const NEW_LABEL_COLOR = '#new-label-color';
+export const LABEL_COLOR_VALUE = '#label-color-value';
+export const LABEL_PREVIEW = '#label-preview';
+export const LABEL_CANCEL_BUTTON = '#label-cancel-button';
+export const LABEL_CREATE_BUTTON = '#label-create-button';
+export const LABEL_LIST = '#labels-wrapper .label-list';

--- a/src/main.js
+++ b/src/main.js
@@ -1,97 +1,76 @@
-import { MainPage } from './components/page/mainPage';
-import { IssueComponent } from './components/page/item/issue';
+// Components
+import { IssuePage } from './pages/issuePage';
+import { LabelPage } from './pages/labelPage';
 
+// Constants
+import {
+  ROOT,
+  ISSUE_PAGE_BUTTON,
+  LABEL_PAGE_BUTTON,
+} from './constants/selector';
+
+// Store
+import GlobalStore, { SET_CURRENT_PAGEG } from './store/global';
+
+// Utils
+import { findElement } from './utils/dom';
 class App {
-  constructor(appRoot) {
-    this.loadPage(appRoot);
+  constructor(issuePage, labelPage) {
+    this.issuePage = issuePage;
+    this.labelPage = labelPage;
+
+    // 첫 디폴트 페이지는 이슈 페이지
+    this.issuePage.initPage();
+
+    // subscribe 등록
+    GlobalStore.subscribe(SET_CURRENT_PAGEG, this.renderPage);
+
+    // 이벤트 등록
+    Object.keys(this.#pageButtons).forEach((pageType) => {
+      const pageButton = findElement(this.#pageButtons[pageType]);
+
+      pageButton.addEventListener('click', () => {
+        // 같은 탭을 클릭했다면
+        if (GlobalStore.getState().currentPage === pageType) {
+          return;
+        }
+
+        GlobalStore.dispatch({
+          type: SET_CURRENT_PAGEG,
+          payload: pageType,
+        });
+      });
+    });
   }
 
-  #page = '';
-  #rawIssues = [];
-  #issueListElement = null;
-  #tabs = {
-    open: null,
-    close: null,
+  #pageButtons = {
+    issue: ISSUE_PAGE_BUTTON,
+    label: LABEL_PAGE_BUTTON,
   };
 
-  loadPage = (appRoot) => {
-    this.fetchIssues().then((issues) => {
-      this.#rawIssues = issues;
-
-      // 메인 페이지 렌더링
-      this.#page = new MainPage(
-        this.filterIssues('open').length,
-        this.filterIssues('close').length
-      );
-      this.#page.attatchTo(appRoot);
-
-      // 이슈 리스트 렌더링
-      this.#issueListElement = document.querySelector('.issue-list ul');
-      this.renderIssues('open'); // 디폴트는 open 상태
-
-      // 이벤트 등록
-      this.#tabs.open = document.getElementById('openTab');
-      this.#tabs.close = document.getElementById('closedTab');
-      this.#tabs.open.addEventListener('click', () => {
-        this.renderIssues('open');
-        this.changeTab('open');
-      });
-      this.#tabs.close.addEventListener('click', () => {
-        this.renderIssues('close');
-        this.changeTab('close');
-      });
-    });
-  };
-
-  fetchIssues = () => {
-    // 반환값을 받을 Promise 객체 생성
-    return new Promise(function (resolve) {
-      fetch('../../data-sources/issues.json') // json 파일 읽어오기
-        .then((response) => {
-          resolve(response.json()); // 읽어온 데이터를 json으로 변환
-        });
-    });
-  };
-
-  filterIssues = (status) => {
-    return pipe(
-      (issues) => issues,
-      filter((issue) => issue.status === status)
-    )(this.#rawIssues);
-  };
-
-  renderIssues = (status) => {
-    // 기존에 그려진 리스트 비워주기
-    this.clearIssues();
-
-    // 상태에 맞게 필터링 한 후
-    const filteredIssues = this.filterIssues(status);
-
-    // 렌더링
-    filteredIssues.forEach((issue) => {
-      const issueComponent = new IssueComponent(issue);
-      issueComponent.attatchTo(this.#issueListElement, 'beforeend');
-    });
-  };
-
-  clearIssues = () => {
-    while (this.#issueListElement.firstChild) {
-      this.#issueListElement.removeChild(this.#issueListElement.firstChild);
+  clearPage = () => {
+    while (findElement(ROOT).firstChild) {
+      findElement(ROOT).removeChild(findElement(ROOT).firstChild);
     }
   };
 
-  changeTab = (clickedStatus) => {
-    // 클릭한 탭과 일치하면 하이라이팅, 아니면 제거
-    Object.keys(this.#tabs).forEach((issueStatus) => {
-      if (issueStatus === clickedStatus) {
-        this.#tabs[issueStatus].classList.add('font-bold');
-      } else {
-        this.#tabs[issueStatus].classList.remove('font-bold');
-      }
-    });
+  renderPage = () => {
+    this.clearPage();
+
+    switch (GlobalStore.getState().currentPage) {
+      case 'issue':
+        this.issuePage.initPage();
+        break;
+      case 'label':
+        this.labelPage.initPage();
+        break;
+    }
   };
 }
 
 window.onload = () => {
-  new App(document.getElementById('app'));
+  const issuePage = new IssuePage();
+  const labelPage = new LabelPage();
+
+  new App(issuePage, labelPage);
 };

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,10 @@ import { MainPage } from './components/page/mainPage';
 import { IssueComponent } from './components/page/item/issue';
 
 class App {
+  constructor(appRoot) {
+    this.loadPage(appRoot);
+  }
+
   #page = '';
   #rawIssues = [];
   #issueListElement = null;
@@ -10,11 +14,40 @@ class App {
     close: null,
   };
 
+  loadPage = (appRoot) => {
+    this.fetchIssues().then((issues) => {
+      this.#rawIssues = issues;
+
+      // 메인 페이지 렌더링
+      this.#page = new MainPage(
+        this.filterIssues('open').length,
+        this.filterIssues('close').length
+      );
+      this.#page.attatchTo(appRoot);
+
+      // 이슈 리스트 렌더링
+      this.#issueListElement = document.querySelector('.issue-list ul');
+      this.renderIssues('open'); // 디폴트는 open 상태
+
+      // 이벤트 등록
+      this.#tabs.open = document.getElementById('openTab');
+      this.#tabs.close = document.getElementById('closedTab');
+      this.#tabs.open.addEventListener('click', () => {
+        this.renderIssues('open');
+        this.changeTab('open');
+      });
+      this.#tabs.close.addEventListener('click', () => {
+        this.renderIssues('close');
+        this.changeTab('close');
+      });
+    });
+  };
+
   fetchIssues = () => {
     // 반환값을 받을 Promise 객체 생성
     return new Promise(function (resolve) {
       fetch('../../data-sources/issues.json') // json 파일 읽어오기
-        .then(function (response) {
+        .then((response) => {
           resolve(response.json()); // 읽어온 데이터를 json으로 변환
         });
     });
@@ -47,45 +80,16 @@ class App {
     }
   };
 
-  changeTab = (status) => {
+  changeTab = (clickedStatus) => {
     // 클릭한 탭과 일치하면 하이라이팅, 아니면 제거
-    Object.keys(this.#tabs).forEach((key) => {
-      if (key === status) {
-        this.#tabs[key].classList.add('font-bold');
+    Object.keys(this.#tabs).forEach((issueStatus) => {
+      if (issueStatus === clickedStatus) {
+        this.#tabs[issueStatus].classList.add('font-bold');
       } else {
-        this.#tabs[key].classList.remove('font-bold');
+        this.#tabs[issueStatus].classList.remove('font-bold');
       }
     });
   };
-
-  constructor(appRoot) {
-    this.fetchIssues().then((issues) => {
-      this.#rawIssues = issues;
-
-      // 메인 페이지 렌더링
-      this.#page = new MainPage(
-        this.filterIssues('open').length,
-        this.filterIssues('close').length
-      );
-      this.#page.attatchTo(appRoot);
-
-      // 이슈 리스트 렌더링
-      this.#issueListElement = document.querySelector('.issue-list ul');
-      this.renderIssues('open'); // 디폴트는 open 상태
-
-      // 이벤트 등록
-      this.#tabs.open = document.getElementById('openTab');
-      this.#tabs.close = document.getElementById('closedTab');
-      this.#tabs.open.addEventListener('click', () => {
-        this.renderIssues('open');
-        this.changeTab('open');
-      });
-      this.#tabs.close.addEventListener('click', () => {
-        this.renderIssues('close');
-        this.changeTab('close');
-      });
-    });
-  }
 }
 
 window.onload = () => {

--- a/src/pages/issuePage.js
+++ b/src/pages/issuePage.js
@@ -1,0 +1,139 @@
+// Components
+import { BaseComponent } from '../components/component';
+import { IssueItem } from '../components/issue/issueItem';
+
+// Templates
+import { getIssueTpl } from '../tpl';
+
+// Constants
+import { ROOT, ISSUE_LIST, OPEN_TAB, CLOSE_TAB } from '../constants/selector';
+
+// Api
+import IssueApi from '../api/issue';
+
+// Store
+import IssueStore, {
+  SET_ISSUE_LIST,
+  SET_OPEN_COUNT,
+  SET_CLOSE_COUNT,
+  SET_CURRENT_TAB,
+} from '../store/issueStore';
+
+// Utils
+import { pipe, filter } from '../utils/fx';
+import { findElement } from '../utils/dom';
+
+export class IssuePage extends BaseComponent {
+  constructor() {
+    super(getIssueTpl());
+  }
+
+  #rootEl = null;
+  #tabs = {
+    open: OPEN_TAB,
+    close: CLOSE_TAB,
+  };
+
+  initPage = async () => {
+    // 데이터 패치
+    const issues = await IssueApi.fetchIssues();
+
+    // 루트 선택 및 페이지 렌더링
+    this.#rootEl = findElement(ROOT);
+    this.attatchTo(this.#rootEl);
+
+    // subscribe 등록
+    IssueStore.subscribe(SET_ISSUE_LIST, this.loadIssuePage);
+    IssueStore.subscribe(SET_OPEN_COUNT, this.renderOpenCount);
+    IssueStore.subscribe(SET_CLOSE_COUNT, this.renderCloseCount);
+    IssueStore.subscribe(SET_CURRENT_TAB, this.renderIssues);
+
+    // action 호출
+    IssueStore.dispatch({
+      type: SET_ISSUE_LIST,
+      payload: issues,
+    });
+    IssueStore.dispatch({
+      type: SET_OPEN_COUNT,
+      payload: this.filterIssues('open').length,
+    });
+    IssueStore.dispatch({
+      type: SET_CLOSE_COUNT,
+      payload: this.filterIssues('close').length,
+    });
+
+    // 이벤트 등록
+    Object.keys(this.#tabs).forEach((tabType) => {
+      const tab = findElement(this.#tabs[tabType]);
+
+      tab.addEventListener('click', () => {
+        IssueStore.dispatch({
+          type: SET_CURRENT_TAB,
+          payload: tabType,
+        });
+        this.changeTab(tabType);
+      });
+    });
+  };
+
+  loadIssuePage = () => {
+    this.removeFrom(this.#rootEl);
+    this.setElement(getIssueTpl());
+    this.attatchTo(this.#rootEl);
+
+    // 이슈 리스트 렌더링
+    this.renderIssues();
+  };
+
+  filterIssues = (status) => {
+    return pipe(
+      (issues) => issues,
+      filter((issue) => issue.status === status)
+    )(IssueStore.getState().issueList);
+  };
+
+  clearIssues = () => {
+    while (findElement(ISSUE_LIST).firstChild) {
+      findElement(ISSUE_LIST).removeChild(findElement(ISSUE_LIST).firstChild);
+    }
+  };
+
+  renderOpenCount = () => {
+    const openTab = findElement(OPEN_TAB);
+    openTab.innerText = `${IssueStore.getState().openCount} Opens`;
+  };
+
+  renderCloseCount = () => {
+    const closeTab = findElement(CLOSE_TAB);
+    closeTab.innerText = `${IssueStore.getState().closeCount} Opens`;
+  };
+
+  renderIssues = () => {
+    // 기존에 그려진 리스트 비워주기
+    this.clearIssues();
+
+    const filteredIssues = this.filterIssues(IssueStore.getState().currentTab);
+    filteredIssues.forEach((issue) => {
+      const issueItem = new IssueItem(issue);
+      issueItem.attatchTo(findElement(ISSUE_LIST), 'beforeend');
+    });
+  };
+
+  changeTab = (clickedTab) => {
+    // 클릭한 탭과 일치하면 하이라이팅, 아니면 제거
+    Object.keys(this.#tabs).forEach((tabType) => {
+      const tab = findElement(this.#tabs[tabType]);
+
+      if (tabType === clickedTab) {
+        tab.classList.add('font-bold');
+      } else {
+        tab.classList.remove('font-bold');
+      }
+    });
+  };
+
+  mounted = () => {
+    // set tab
+    this.changeTab(IssueStore.getState().currentTab);
+  };
+}

--- a/src/pages/labelPage.js
+++ b/src/pages/labelPage.js
@@ -1,0 +1,215 @@
+// Components
+import { BaseComponent } from '../components/component';
+import { LabelItem } from '../components/label/labelItem';
+
+// Templates
+import { getLabelTpl } from '../tpl';
+
+// Constants
+import {
+  ROOT,
+  LABEL_COUNT,
+  NEW_LABEL_BUTTON,
+  LABEL_INPUT_FORM,
+  LABEL_NAME_INPUT,
+  LABEL_DESCRIPTION_INPUT,
+  NEW_LABEL_COLOR,
+  LABEL_COLOR_VALUE,
+  LABEL_PREVIEW,
+  LABEL_CANCEL_BUTTON,
+  LABEL_CREATE_BUTTON,
+  LABEL_LIST,
+} from '../constants/selector';
+
+// Utils
+import { findElement } from '../utils/dom';
+
+// Api
+import LabelApi from '../api/label';
+
+// Store
+import LabelStore, {
+  SET_LABEL_LIST,
+  SET_LABEL_ITEM,
+  ADD_LABEL,
+} from '../store/labelStore';
+
+export class LabelPage extends BaseComponent {
+  constructor() {
+    super(getLabelTpl());
+  }
+
+  #rootEl = null;
+
+  initPage = async () => {
+    // 데이터 패치
+    const labels = await LabelApi.fetchLabels();
+
+    // 루트 선택 및 페이지 렌더링
+    this.#rootEl = findElement(ROOT);
+    this.attatchTo(this.#rootEl);
+
+    // subscribe 등록
+    LabelStore.subscribe(SET_LABEL_LIST, this.loadLabelPage);
+    LabelStore.subscribe(SET_LABEL_ITEM, this.validateForm);
+    LabelStore.subscribe(ADD_LABEL, this.renderLabels);
+    LabelStore.subscribe(ADD_LABEL, this.renderLabelCount);
+
+    // action 호출
+    LabelStore.dispatch({
+      type: SET_LABEL_LIST,
+      payload: labels,
+    });
+
+    // 이벤트 등록
+    const newLabelButton = findElement(NEW_LABEL_BUTTON);
+    newLabelButton.addEventListener('click', this.onNewLabelButtonClick);
+
+    const labelNameInput = findElement(LABEL_NAME_INPUT);
+    labelNameInput.addEventListener('input', this.onLabelNameInputChange);
+
+    const labelDescriptionInput = findElement(LABEL_DESCRIPTION_INPUT);
+    labelDescriptionInput.addEventListener(
+      'input',
+      this.onLabelDescriptionInputChange
+    );
+
+    const newLabelColorButton = findElement(NEW_LABEL_COLOR);
+    newLabelColorButton.addEventListener(
+      'click',
+      this.onNewLabelColorButtonClick
+    );
+
+    const labelCancelButton = findElement(LABEL_CANCEL_BUTTON);
+    labelCancelButton.addEventListener('click', this.onLabelCancelButtonClick);
+
+    const labelSubmitButton = findElement(LABEL_INPUT_FORM);
+    labelSubmitButton.addEventListener('submit', this.onSubmit);
+  };
+
+  loadLabelPage = () => {
+    this.removeFrom(this.#rootEl);
+    this.setElement(getLabelTpl());
+    this.attatchTo(this.#rootEl);
+
+    // 라벨 리스트 렌더링
+    this.renderLabels();
+  };
+
+  renderLabelCount = () => {
+    const labelCountArea = findElement(LABEL_COUNT);
+    labelCountArea.innerText = `${
+      LabelStore.getState().labelList.length
+    } Labels`;
+  };
+
+  clearLabels = () => {
+    while (findElement(LABEL_LIST).firstChild) {
+      findElement(LABEL_LIST).removeChild(findElement(LABEL_LIST).firstChild);
+    }
+  };
+
+  renderLabels = () => {
+    // 기존에 그려진 리스트 비워주기
+    this.clearLabels();
+
+    const labelList = LabelStore.getState().labelList;
+    labelList.forEach((label) => {
+      const labelItem = new LabelItem(label);
+      labelItem.attatchTo(findElement(LABEL_LIST), 'beforeend');
+    });
+  };
+
+  onNewLabelButtonClick = () => {
+    const labelInputForm = findElement(LABEL_INPUT_FORM);
+    labelInputForm.classList.remove('hidden');
+  };
+
+  onLabelNameInputChange = (e) => {
+    const labelItem = { ...LabelStore.getState().labelItem };
+    labelItem.name = e.target.value;
+    LabelStore.dispatch({
+      type: SET_LABEL_ITEM,
+      payload: labelItem,
+    });
+  };
+
+  onLabelDescriptionInputChange = (e) => {
+    const labelItem = { ...LabelStore.getState().labelItem };
+    labelItem.description = e.target.value;
+    LabelStore.dispatch({
+      type: SET_LABEL_ITEM,
+      payload: labelItem,
+    });
+  };
+
+  onNewLabelColorButtonClick = () => {
+    const labelPreview = findElement(LABEL_PREVIEW);
+    const newLabelColorButton = findElement(NEW_LABEL_COLOR);
+    const labelColorInput = findElement(LABEL_COLOR_VALUE);
+
+    const [r, g, b] = this.randomRgb();
+    const colorStyle = `background-color: rgb(${r}, ${g}, ${b})`;
+    newLabelColorButton.style = colorStyle;
+    labelPreview.style = colorStyle;
+
+    const labelItem = { ...LabelStore.getState().labelItem };
+    const hexRgb = this.rgbToHex(r, g, b);
+    labelColorInput.value = `#${hexRgb}`;
+    labelItem.color = hexRgb;
+    LabelStore.dispatch({
+      type: SET_LABEL_ITEM,
+      payload: labelItem,
+    });
+  };
+
+  onLabelCancelButtonClick = () => {
+    const labelInputForm = findElement(LABEL_INPUT_FORM);
+    labelInputForm.classList.add('hidden');
+  };
+
+  onSubmit = (e) => {
+    e.preventDefault();
+
+    LabelStore.dispatch({
+      type: ADD_LABEL,
+    });
+  };
+
+  randomRgb = () => {
+    let r = Math.floor(Math.random() * 256);
+    let g = Math.floor(Math.random() * 256);
+    let b = Math.floor(Math.random() * 256);
+
+    return [r, g, b];
+  };
+
+  rgbToHex = (r, g, b) => {
+    r = r.toString(16).length === 1 ? '0' + r.toString(16) : r.toString(16);
+    g = g.toString(16).length === 1 ? '0' + g.toString(16) : g.toString(16);
+    b = b.toString(16).length === 1 ? '0' + b.toString(16) : b.toString(16);
+
+    return r + g + b;
+  };
+
+  validateForm = () => {
+    const labelCreateButton = findElement(LABEL_CREATE_BUTTON);
+    const labelItem = LabelStore.getState().labelItem;
+
+    let flag = true;
+    Object.keys(labelItem).forEach((key) => {
+      // 하나라도 입력이 안 된 것이 있다면
+      if (!labelItem[key]) {
+        flag = false;
+      }
+    });
+
+    if (flag) {
+      labelCreateButton.disabled = false;
+      labelCreateButton.classList.remove('opacity-50');
+    } else {
+      labelCreateButton.disabled = true;
+      labelCreateButton.classList.add('opacity-50');
+    }
+  };
+}

--- a/src/store/global.js
+++ b/src/store/global.js
@@ -1,0 +1,21 @@
+import Store from './store';
+
+export const SET_CURRENT_PAGEG = 'SET_CURRENT_PAGE';
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case SET_CURRENT_PAGEG:
+      return {
+        ...state,
+        currentPage: action.payload,
+      };
+  }
+};
+
+const initialState = {
+  currentPage: 'issue',
+};
+
+const globalStore = Store.createStore(initialState, reducer);
+
+export default globalStore;

--- a/src/store/issueStore.js
+++ b/src/store/issueStore.js
@@ -1,0 +1,42 @@
+import Store from './store';
+
+export const SET_ISSUE_LIST = 'SET_ISSUE_LIST';
+export const SET_OPEN_COUNT = 'SET_OPEN_COUNT';
+export const SET_CLOSE_COUNT = 'SET_CLOSE_COUNT';
+export const SET_CURRENT_TAB = 'SET_CURRENT_TAB';
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case SET_ISSUE_LIST:
+      return {
+        ...state,
+        issueList: [...action.payload],
+      };
+    case SET_OPEN_COUNT:
+      return {
+        ...state,
+        openCount: action.payload,
+      };
+    case SET_CLOSE_COUNT:
+      return {
+        ...state,
+        closeCount: action.payload,
+      };
+    case SET_CURRENT_TAB:
+      return {
+        ...state,
+        currentTab: action.payload,
+      };
+  }
+};
+
+const initialState = {
+  issueList: [],
+  openCount: 0,
+  closeCount: 0,
+  currentTab: 'open',
+};
+
+const issueStore = Store.createStore(initialState, reducer);
+
+export default issueStore;

--- a/src/store/labelStore.js
+++ b/src/store/labelStore.js
@@ -1,0 +1,38 @@
+import Store from './store';
+
+export const SET_LABEL_LIST = 'SET_LABEL_LIST';
+export const SET_LABEL_ITEM = 'SET_LABEL_ITEM';
+export const ADD_LABEL = 'ADD_LABEL';
+
+const reducer = (state, action) => {
+  switch (action.type) {
+    case SET_LABEL_LIST:
+      return {
+        ...state,
+        labelList: [...action.payload],
+      };
+    case SET_LABEL_ITEM:
+      return {
+        ...state,
+        labelItem: { ...action.payload },
+      };
+    case ADD_LABEL:
+      return {
+        ...state,
+        labelList: [...state.labelList, state.labelItem],
+      };
+  }
+};
+
+const initialState = {
+  labelList: [],
+  labelItem: {
+    name: '',
+    description: '',
+    color: '',
+  },
+};
+
+const labelStore = Store.createStore(initialState, reducer);
+
+export default labelStore;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,49 @@
+const createStore = (initialState, reducer) => {
+  let state = initialState;
+  const events = {};
+
+  // 상태 변화 시 실행할 함수 등록
+  // eventCallback는 기명 함수를 등록해준다.
+  const subscribe = (actionType, eventCallback) => {
+    if (!events[actionType]) {
+      events[actionType] = [];
+    }
+
+    // 기존에 없는 이벤트 콜백 함수만 등록해준다.
+    if (
+      events[actionType].findIndex(
+        (existingEventCallback) =>
+          existingEventCallback.name === eventCallback.name
+      ) === -1
+    ) {
+      events[actionType].push(eventCallback);
+    }
+  };
+
+  // 이벤트에 해당하는 함수 모두 실행
+  const publish = (actionType) => {
+    if (!events[actionType]) {
+      return;
+    }
+    events[actionType].forEach((cb) => cb());
+  };
+
+  // 상태에 이벤트와 필요한 데이터를 보내는 함수
+  const dispatch = (action) => {
+    // action에는 type(이벤트), payload(데이터)가 있음
+    state = reducer(state, action);
+    publish(action.type);
+  };
+
+  const getState = () => state;
+
+  return {
+    getState,
+    subscribe,
+    dispatch,
+  };
+};
+
+export default {
+  createStore,
+};

--- a/src/tpl.js
+++ b/src/tpl.js
@@ -1,4 +1,7 @@
-export function getIssueTpl(openCount = 0, closedCount = 0) {
+import IssueStore from './store/issueStore';
+import LabelStore from './store/labelStore';
+
+export function getIssueTpl() {
   /* html */
   return `
     <div id="issue-wrapper" class="w-9/12 m-auto min-w-min">
@@ -18,7 +21,7 @@ export function getIssueTpl(openCount = 0, closedCount = 0) {
       </nav>
 
       <div class="new-issue p-3 py-1 base-outer flex items-center justify-center w-2/12 ml-4 bg-green-700 text-white">
-        <a href="#">New
+        <a href="javascript:void(0);">New
           issue</a></div>
 
     </div>
@@ -30,8 +33,12 @@ export function getIssueTpl(openCount = 0, closedCount = 0) {
         </div>
 
         <div class="statusTab flex">
-          <div id="openTab" class="whitespace-nowrap open-count font-bold cursor-pointer">${openCount} Opens</div>
-          <div id="closedTab" class="whitespace-nowrap close-count ml-3 cursor-pointer">${closedCount} Closed</div>
+          <div id="openTab" class="whitespace-nowrap open-count font-bold cursor-pointer">${
+            IssueStore.getState().openCount
+          } Opens</div>
+          <div id="closeTab" class="whitespace-nowrap close-count ml-3 cursor-pointer">${
+            IssueStore.getState().closeCount
+          } Closed</div>
         </div>
 
         <div class="details-list flex ml-auto">
@@ -108,13 +115,13 @@ export function getLabelTpl() {
       </form>
     </div>
 
-    <div class="new-label-button cursor-pointer p-1 py-1 base-outer flex items-center justify-center w-2/12 ml-4 bg-green-700 text-white">
-      <a href="#">New label</a>
+    <div id="newLabelButton" class="new-label-button cursor-pointer p-1 py-1 base-outer flex items-center justify-center w-2/12 ml-4 bg-green-700 text-white">
+      <a href="javascript:void(0);">New label</a>
     </div>
   </div>
 
 
-  <form class="hidden p-3 mb-3 mt-6 border rounded-sm font-bold" id="new-label-form" action="/labels" accept-charset="UTF-8" method="post">
+  <form id="labelInputForm" class="hidden p-3 mb-3 mt-6 border rounded-sm font-bold" id="new-label-form" action="/labels" accept-charset="UTF-8" method="post">
     <div class="form-group mt-0 mb-2"
       data-url-template="/labels/preview/" data-default-name="Label preview">
 
@@ -184,7 +191,7 @@ export function getLabelTpl() {
           <div class="ml-2">
             <input type="text" id="label-color-value" name="label-color[description]"
             class="w-full p-2 base-outer focus:outline-none"
-            placeholder="#color" value="" maxlength="100">
+            placeholder="#color" value="" maxlength="100" disabled>
           </div>
 
         </dd>
@@ -194,9 +201,9 @@ export function getLabelTpl() {
       <!--new label actions-->
       <div
         class="form-group my-2 flex mt-10">
-        <button type="button" class="base-outer p-2 mr-4"> Cancel
+        <button id="label-cancel-button" type="button" class="base-outer p-2 mr-4"> Cancel
         </button>
-        <button id="label-create-button" type="submit" class="base-outer p-2 mr-4 bg-green-700 opacity-50 text-white" disabled=""> Create label
+        <button id="label-create-button" type="submit" class="base-outer p-2 mr-4 bg-green-700 opacity-50 text-white" disabled> Create label
         </button>
       </div>
       <!--END new label actions-->
@@ -210,7 +217,9 @@ export function getLabelTpl() {
     <div class="label-header h-16 flex justify-between items-center border-b">
 
       <div class="mr-3 d-none pl-4">
-        <div class="whitespace-nowrap open-count font-bold cursor-pointer">6 Labels</div>
+        <div id="labelCount" class="whitespace-nowrap open-count font-bold cursor-pointer">${
+          LabelStore.getState().labelList.length
+        } Labels</div>
       </div>
 
       <div class="details-list flex ml-auto">

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -1,0 +1,3 @@
+export const findElement = (selector, fromElement = document) => {
+  return fromElement.querySelector(selector);
+};

--- a/src/utils/fx.js
+++ b/src/utils/fx.js
@@ -1,19 +1,19 @@
 // 함수를 전달 받아, 함수의 인자가 하나라면 함수를 리턴, 아니라면 함수 호출을 한다.
-const curry =
+export const curry =
   (f) =>
   (a, ..._) =>
     _.length ? f(a, ..._) : (..._) => f(a, ..._);
 
 // reduce를 이용해 인자로 전달한 함수들을 순회하며 호출을 누적해 나간다.
-const go = (...args) => reduce((a, f) => f(a), args);
+export const go = (...args) => reduce((a, f) => f(a), args);
 
 // 최종적으로 go를 호출하는 함수를 리턴한다.
-const pipe =
+export const pipe =
   (f, ...fs) =>
   (...as) =>
     go(f(...as), ...fs);
 
-const map = curry((f, iter) => {
+export const map = curry((f, iter) => {
   let res = [];
   for (const a of iter) {
     res.push(f(a));
@@ -21,7 +21,7 @@ const map = curry((f, iter) => {
   return res;
 });
 
-const filter = curry((f, iter) => {
+export const filter = curry((f, iter) => {
   let res = [];
   for (const a of iter) {
     if (f(a)) res.push(a);
@@ -29,7 +29,7 @@ const filter = curry((f, iter) => {
   return res;
 });
 
-const reduce = curry((f, acc, iter) => {
+export const reduce = curry((f, acc, iter) => {
   // acc를 사용자가 넘기지 않았을 때의 처리
   if (!iter) {
     iter = acc[Symbol.iterator]();


### PR DESCRIPTION
### 구현 요구사항 체크리스트

- 초기 로딩 시에 다음과 같은 화면을 보여준다.
ㄴ Label 갯수 표시
ㄴ Label 리스트 노출
- new Label을 누르면 새로운 입력창이 노출된다.
- 초기 데이터는 fetch 요청을 통해서 가져온다.
ㄴ 따로 api로 분리하여 issue 페이지에도 마찬가지로 적용
- 객체 구성
ㄴ 이슈리스트 아이템, 라벨리스트 아이템을 따로 객체로 빼서 관리하였음
- 객체 표현 방식
ㄴ ES Classes를 한 개 이상 사용하였음
ㄴ 객체리터럴 방식도 사용하였음
- 객체 의존성
ㄴ issue와 label을 관리하는 store 객체를 따로 만들어 사용하였음
ㄴ Observer 패턴을 흉내내어 상태관리를 하였음